### PR TITLE
Refactored LogMessage to be smaller in size

### DIFF
--- a/Engine/src/ANE/Core/Layers/Panels/EditorLogPanel.h
+++ b/Engine/src/ANE/Core/Layers/Panels/EditorLogPanel.h
@@ -32,6 +32,7 @@ namespace Engine
 
     private:
         void OnScroll(Vector2 delta);
+        void ResizeLoggerFilter();
 
     private:
         static const Vector4 colorTrace;
@@ -40,7 +41,9 @@ namespace Engine
         static const Vector4 colorError;
 
         LogLevelCategories _levelFilter;
-        entt::dense_map<std::string, bool> _loggerNameFilter;
+        std::vector<uint8> _loggerIdFilter; // vector<bool> cant be used with imgui
+
+        bool _loggerNameFilterOpen;
 
         bool _wrap = true;
         bool _autoScroll = true;

--- a/Engine/src/ANE/Core/Log/LogFileWriter.cpp
+++ b/Engine/src/ANE/Core/Log/LogFileWriter.cpp
@@ -2,6 +2,8 @@
 #include "LogFileWriter.h"
 #include <filesystem>
 #include <string>
+
+#include "LogMessage.h"
 #include "ANE/Utilities/LoggingUtilities.h"
 
 namespace Engine
@@ -34,25 +36,16 @@ namespace Engine
         }
     }
 
-    std::string LogFileWriter::ConstructMessage(LogMessage& msg)
+    std::string LogFileWriter::ConstructMessage(const LogMessage& msg)
     {
         ANE_DEEP_PROFILE_FUNCTION();
 
-        std::string messageBuilder;
-        const std::string levelName = LoggingUtilities::ToString(msg.LevelCategory);
-
-        messageBuilder.append(std::format("[{0} {1}", msg.LoggerName, levelName));
-
-        messageBuilder.append(std::format(" {0}] ", msg.Time));
-
-        messageBuilder.append(std::format("[{0}] ", msg.Source));
-
-        messageBuilder.append(msg.Message);
+        std::string messageBuilder = msg.ConstructMessage(true, true, true, true);
 
         return messageBuilder;
     }
 
-    void LogFileWriter::WriteToFile(LogMessage& msg)
+    void LogFileWriter::WriteToFile(const LogMessage& msg)
     {
         ANE_DEEP_PROFILE_FUNCTION();
 

--- a/Engine/src/ANE/Core/Log/LogFileWriter.h
+++ b/Engine/src/ANE/Core/Log/LogFileWriter.h
@@ -10,11 +10,11 @@ namespace Engine
     {
     public:
         void GetOldestFile(std::filesystem::path& oldestFile) const;
-        void WriteToFile(LogMessage& msg);
+        void WriteToFile(const LogMessage& msg);
 
     private:
         [[nodiscard("Return value not used.")]] int DirectoryCount() const;
-        [[nodiscard("Return value not used.")]] static std::string ConstructMessage(LogMessage& msg);
+        [[nodiscard("Return value not used.")]] static std::string ConstructMessage(const LogMessage& msg);
 
         std::ofstream _outputFile;
         std::string _fileName;

--- a/Engine/src/ANE/Core/Log/LogMessage.cpp
+++ b/Engine/src/ANE/Core/Log/LogMessage.cpp
@@ -1,0 +1,122 @@
+#include "anepch.h"
+#include "LogMessage.h"
+
+#include "ANE/Utilities/LoggingUtilities.h"
+
+namespace Engine
+{
+    LogMessage::LogMessage(const log_msg& logMsg)
+    {
+        std::string tempString;
+        SegmentedMessage.clear();
+
+        Logging::LoggerNameFormatter.format(logMsg, tempString);
+        tempString.erase(tempString.length()-2); //spdlog appends linebreaks
+
+        LoggerNameIndex = Logging::GetRegisteredLoggerIndex(tempString);
+
+        tempString.clear();
+        Logging::TimeFormatter.format(logMsg, tempString);
+        tempString.erase(tempString.length()-2);
+
+        SegmentedMessage.append(tempString);
+
+        tempString.clear();
+        Logging::SourceFormatter.format(logMsg, tempString);
+        tempString.erase(tempString.length()-2);
+
+        SourceIndex = SegmentedMessage.length();
+        SegmentedMessage.append(tempString);
+
+        MessageIndex = SegmentedMessage.length();
+        SegmentedMessage.append(logMsg.payload);
+
+        switch (logMsg.level)
+        {
+            case spdlog::level::trace:
+                LevelCategory = LogLevelCategory::Trace;
+            break;
+            case spdlog::level::debug:
+                LevelCategory = LogLevelCategory::Debug;
+            break;
+            case spdlog::level::info:
+                LevelCategory = LogLevelCategory::Info;
+            break;
+            case spdlog::level::warn:
+                LevelCategory = LogLevelCategory::Warn;
+            break;
+            case spdlog::level::err:
+            case spdlog::level::critical:
+                LevelCategory = LogLevelCategory::Error;
+            break;
+            default:
+                LevelCategory = LogLevelCategory::None;
+            break;
+        }
+    }
+
+    std::string LogMessage::ConstructMessage(const bool showLoggerName, const bool showLevel, const bool showTime, const bool showSource) const
+    {
+        // Right now using append, from searches ostream is slower?
+        std::string fullMessage;
+        if(showLoggerName && showLevel)
+        {
+            fullMessage.append(std::format("[{0} {1}", RetrieveLoggerName(), RetrieveLevel()));
+        }
+        else if(showLoggerName)
+        {
+            fullMessage.append(std::format("[{0}", RetrieveLoggerName()));
+        }
+        else if(showLevel)
+        {
+            fullMessage.append(std::format("[{0}", RetrieveLevel()));
+        }
+
+        if(showTime && (showLevel || showLoggerName))
+        {
+            fullMessage.append(std::format(" {0}] ", RetrieveTime()));
+        }
+        else if(showTime)
+        {
+            fullMessage.append(std::format("[{0}] ", RetrieveTime()));
+        }
+        else if((showLevel || showLoggerName))
+        {
+            fullMessage.append("] ");
+        }
+
+        if(showSource)
+        {
+            fullMessage.append(std::format("[{0}] ", RetrieveSource()));
+        }
+
+        fullMessage.append(RetrieveMessage());
+
+        return fullMessage;
+    }
+
+    std::string LogMessage::RetrieveLoggerName() const
+    {
+        return LoggingUtilities::ToLoggerName(LoggerNameIndex);
+    }
+
+    std::string LogMessage::RetrieveLevel() const
+    {
+        return LoggingUtilities::ToString(LevelCategory);
+    }
+
+    std::string LogMessage::RetrieveTime() const
+    {
+        return SegmentedMessage.substr(0, SourceIndex);
+    }
+
+    std::string LogMessage::RetrieveSource() const
+    {
+        return SegmentedMessage.substr(SourceIndex, MessageIndex - SourceIndex);
+    }
+
+    std::string LogMessage::RetrieveMessage() const
+    {
+        return SegmentedMessage.substr(MessageIndex, SegmentedMessage.length() - SourceIndex);
+    }
+}

--- a/Engine/src/ANE/Core/Log/LogMessage.h
+++ b/Engine/src/ANE/Core/Log/LogMessage.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace Engine
+{
+    using log_msg = spdlog::details::log_msg;
+
+    //log_msg
+    struct LogMessage
+    {
+        std::string SegmentedMessage;
+
+        LoggerIndex LoggerNameIndex;
+        LogLevelCategory LevelCategory;
+        uint16 SourceIndex;
+        uint16 MessageIndex;
+
+        LogMessage() = default;
+        LogMessage(const log_msg& logMsg);
+        LogMessage(const LogMessage& other) = default;
+        LogMessage& operator=(const LogMessage& other) = default;
+
+        std::string ConstructMessage(bool showLoggerName, bool showLevel, bool showTime, bool showSource) const;
+
+        std::string RetrieveLoggerName() const;
+
+        std::string RetrieveLevel() const;
+
+        std::string RetrieveTime() const;
+
+        std::string RetrieveSource() const;
+
+        std::string RetrieveMessage() const;
+    };
+}

--- a/Engine/src/ANE/Core/Log/Logging.h
+++ b/Engine/src/ANE/Core/Log/Logging.h
@@ -7,6 +7,7 @@
 #pragma warning(push, 0)
 #include <spdlog/spdlog.h>
 #include "LoggingTypes.h"
+#include "LogMessage.h"
 #pragma warning(pop)
 
 //todo: write a custom sink for logfilewriter so that you can get a full stacktrace
@@ -43,6 +44,16 @@ namespace Engine
         static const std::vector<std::string>& GetRegisteredLoggerNames();
 
         /**
+        * Returns a name of registered logger by index
+        */
+        static const std::string& GetRegisteredLoggerName(LoggerIndex loggerId);
+
+        /**
+        * Returns a name of registered loggers index by name
+        */
+        static LoggerIndex GetRegisteredLoggerIndex(std::string const& name);
+
+        /**
         * Returns a list of unformatted logging messages
         */
         static const std::list<LogMessage>& GetMessages();
@@ -54,6 +65,11 @@ namespace Engine
     private:
         static std::shared_ptr<spdlog::logger> CreateLogger(const std::string& loggerName);
         static void OnSink(const log_msg& logMsg);
+
+    public:
+        static spdlog::pattern_formatter LoggerNameFormatter;
+        static spdlog::pattern_formatter SourceFormatter;
+        static spdlog::pattern_formatter TimeFormatter;
 
     private:
         inline static std::list<LogMessage> _logMessages{100};

--- a/Engine/src/ANE/Core/Log/LoggingTypes.h
+++ b/Engine/src/ANE/Core/Log/LoggingTypes.h
@@ -4,6 +4,7 @@
 namespace Engine
 {
     typedef uint8 LogLevelCategories;
+    typedef uint16 LoggerIndex;
 
     enum class LogLevelCategory : uint8
     {
@@ -15,14 +16,4 @@ namespace Engine
         Error = BIT(4)
     };
     ENUM_CLASS_OPERATORS(LogLevelCategory);
-
-    //log_msg
-    struct LogMessage
-    {
-        std::string Time;
-        std::string Source;
-        std::string LoggerName;
-        LogLevelCategory LevelCategory;
-        std::string Message;
-    };
 }

--- a/Engine/src/ANE/Utilities/LoggingUtilities.h
+++ b/Engine/src/ANE/Utilities/LoggingUtilities.h
@@ -16,5 +16,10 @@ namespace Engine
                 default: return "Unknown";
             }
         }
+
+        inline std::string ToLoggerName(const LoggerIndex loggerNameIndex)
+        {
+            return Logging::GetRegisteredLoggerName(loggerNameIndex);
+        }
     }
 }


### PR DESCRIPTION
- LogMessage now stores segments in a single string as substrings
- LoggerName is stored as index and accessed from Logging in LogMessage and EditorLogPanel instead of string.
- EditorLogPanel and LogFileWriter uses same formatter